### PR TITLE
feat(admin-ui): redesign dialogs and selects

### DIFF
--- a/web/static/css/input.css
+++ b/web/static/css/input.css
@@ -3,6 +3,27 @@
 @tailwind utilities;
 
 @layer components {
+  .form-select {
+    @apply w-full appearance-none rounded-xl border border-slate-200 bg-white/95 px-3 py-2 text-sm font-medium text-slate-700 shadow-sm transition duration-200 ease-out focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100 hover:border-blue-300 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-100 dark:hover:border-blue-500/50 dark:focus:border-blue-500/60 dark:focus:ring-blue-500/30;
+    background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20fill%3D'none'%20viewBox%3D'0%200%2020%2020'%3E%3Cpath%20stroke%3D'%2394a3b8'%20stroke-linecap%3D'round'%20stroke-linejoin%3D'round'%20stroke-width%3D'1.5'%20d%3D'M6%208l4%204%204-4'%2F%3E%3C%2Fsvg%3E");
+    background-repeat: no-repeat;
+    background-position: right 0.75rem center;
+    background-size: 0.9rem;
+    padding-right: 2.75rem;
+  }
+
+  .form-select:disabled {
+    @apply cursor-not-allowed border-slate-200 bg-slate-100 text-slate-400 opacity-75 dark:border-slate-800 dark:bg-slate-800/60 dark:text-slate-500;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .form-select {
+      background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20fill%3D'none'%20viewBox%3D'0%200%2020%2020'%3E%3Cpath%20stroke%3D'%23cbd5f5'%20stroke-linecap%3D'round'%20stroke-linejoin%3D'round'%20stroke-width%3D'1.5'%20d%3D'M6%208l4%204%204-4'%2F%3E%3C%2Fsvg%3E");
+    }
+  }
+}
+
+@layer components {
   .post-content {
     @apply space-y-6 text-base leading-relaxed text-slate-700 dark:text-slate-200;
   }

--- a/web/template/admin/about_edit.html
+++ b/web/template/admin/about_edit.html
@@ -111,10 +111,10 @@
 
 			submit() {
 				const content = this.editor ? this.editor.value() : this.form.content;
-				if (!content || !content.trim()) {
-					alert('请填写关于我内容');
-					return;
-				}
+                                if (!content || !content.trim()) {
+                                        window.AdminUI.toast({ message: '请填写关于我内容', type: 'warning' });
+                                        return;
+                                }
 
 				this.loading = true;
 				fetch('/admin/api/pages/about', {
@@ -124,22 +124,22 @@
 				})
 					.then(response => response.json())
 					.then(data => {
-						if (data.error) {
-							alert(data.error);
-							return;
-						}
-						if (data.message) {
-							this.form.content = content;
-							alert(data.message);
-							this.updatedAt = data.page && data.page.updatedAt ? data.page.updatedAt : this.updatedAt;
-							if (this.editor && this.editor.clearAutosavedValue) {
-								this.editor.clearAutosavedValue();
-							}
-						}
-					})
-					.catch(() => {
-						alert('保存失败，请稍后重试');
-					})
+                                                if (data.error) {
+                                                        window.AdminUI.toast({ message: data.error, type: 'error' });
+                                                        return;
+                                                }
+                                                if (data.message) {
+                                                        this.form.content = content;
+                                                        window.AdminUI.toast({ message: data.message, type: 'success' });
+                                                        this.updatedAt = data.page && data.page.updatedAt ? data.page.updatedAt : this.updatedAt;
+                                                        if (this.editor && this.editor.clearAutosavedValue) {
+                                                                this.editor.clearAutosavedValue();
+                                                        }
+                                                }
+                                        })
+                                        .catch(() => {
+                                                window.AdminUI.toast({ message: '保存失败，请稍后重试', type: 'error' });
+                                        })
 					.finally(() => {
 						this.loading = false;
 					});

--- a/web/template/admin/habit_edit.html
+++ b/web/template/admin/habit_edit.html
@@ -74,7 +74,7 @@
 				</label>
 				<label class="flex flex-col gap-2 text-xs text-slate-600 dark:text-slate-300">
 					<span>当前状态</span>
-					<select name="status" class="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 transition-colors focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-100 dark:focus:border-blue-500/60 dark:focus:ring-blue-500/30">
+                                    <select name="status" class="form-select">
 						<option value="active" {{if ne .habit.Status "inactive"}}selected{{end}}>启用</option>
 						<option value="inactive" {{if eq .habit.Status "inactive"}}selected{{end}}>停用</option>
 					</select>
@@ -129,24 +129,31 @@
 				});
 		});
 
-		if (deleteButton && habitId) {
-			deleteButton.addEventListener('click', () => {
-				if (!confirm('确认删除该习惯？操作不可撤销。')) {
-					return;
-				}
-				fetch(`/admin/api/habits/${habitId}`, { method: 'DELETE' })
-					.then(response => response.json())
-					.then(data => {
-						if (data.error) {
-							throw new Error(data.error);
-						}
-						window.location.href = '/admin/habits';
-					})
-					.catch(() => {
-						displayError('删除失败，请稍后重试');
-					});
-			});
-		}
+                if (deleteButton && habitId) {
+                        deleteButton.addEventListener('click', async () => {
+                                const confirmed = await window.AdminUI.confirm({
+                                        title: '删除习惯',
+                                        message: '确认删除该习惯？操作不可撤销。',
+                                        confirmText: '删除',
+                                        cancelText: '保留',
+                                        tone: 'danger',
+                                });
+                                if (!confirmed) {
+                                        return;
+                                }
+                                fetch(`/admin/api/habits/${habitId}`, { method: 'DELETE' })
+                                        .then(response => response.json())
+                                        .then(data => {
+                                                if (data.error) {
+                                                        throw new Error(data.error);
+                                                }
+                                                window.location.href = '/admin/habits';
+                                        })
+                                        .catch(() => {
+                                                displayError('删除失败，请稍后重试');
+                                        });
+                        });
+                }
 
 		function submitHabit(payload) {
 			const url = habitId ? `/admin/api/habits/${habitId}` : '/admin/api/habits';

--- a/web/template/admin/habit_list.html
+++ b/web/template/admin/habit_list.html
@@ -19,7 +19,7 @@
 
 			<label class="flex flex-col gap-2">
 				<span class="text-sm font-medium text-slate-700 dark:text-slate-200">状态</span>
-				<select name="status" class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 transition-colors focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-100 dark:focus:border-blue-500/60 dark:focus:ring-blue-500/30">
+                                <select name="status" class="form-select">
 					<option value="" {{if eq .filter.Status ""}}selected{{end}}>全部</option>
 					<option value="active" {{if eq .filter.Status "active"}}selected{{end}}>启用中</option>
 					<option value="inactive" {{if eq .filter.Status "inactive"}}selected{{end}}>已停用</option>
@@ -28,7 +28,7 @@
 
 			<label class="flex flex-col gap-2">
 				<span class="text-sm font-medium text-slate-700 dark:text-slate-200">类型标签</span>
-				<select name="type" class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 transition-colors focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-100 dark:focus:border-blue-500/60 dark:focus:ring-blue-500/30">
+                                <select name="type" class="form-select">
 					<option value="" {{if eq .filter.TypeTag ""}}selected{{end}}>全部类型</option>
 					{{range .typeTags}}
 					<option value="{{.}}" {{if eq $.filter.TypeTag .}}selected{{end}}>{{.}}</option>
@@ -204,12 +204,12 @@
 		elements.next.addEventListener('click', () => shiftRange(1));
 		elements.refreshLogs.addEventListener('click', () => loadCalendar());
 
-		elements.quickForm.addEventListener('submit', event => {
-			event.preventDefault();
-			if (!state.habitId) {
-				alert('请先选择一个习惯');
-				return;
-			}
+                elements.quickForm.addEventListener('submit', event => {
+                        event.preventDefault();
+                        if (!state.habitId) {
+                                window.AdminUI.toast({ message: '请先选择一个习惯', type: 'warning' });
+                                return;
+                        }
 			const formData = new FormData(elements.quickForm);
 			const payload = {
 				log_date: formData.get('log_date'),
@@ -226,10 +226,10 @@
 					elements.quickForm.reset();
 					loadCalendar();
 				})
-				.catch(() => {
-					alert('打卡失败，请稍后再试');
-				});
-		});
+                                .catch(() => {
+                                        window.AdminUI.toast({ message: '打卡失败，请稍后再试', type: 'error' });
+                                });
+                });
 
 		function selectHabit(id) {
 			state.habitId = id;
@@ -278,10 +278,10 @@
 					state.rangeEnd = data.range.end;
 					renderCalendar(data);
 				})
-				.catch(() => {
-					alert('加载日历数据失败');
-				});
-		}
+                                .catch(() => {
+                                        window.AdminUI.toast({ message: '加载日历数据失败', type: 'error' });
+                                });
+                }
 
 		function renderCalendar(data) {
 			elements.title.textContent = data.habit.name;
@@ -357,17 +357,29 @@
 			button.appendChild(top);
 			button.appendChild(body);
 
-			if (log) {
-				button.addEventListener('click', () => {
-					if (!confirm('删除该打卡记录？')) {
-						return;
-					}
-					fetch(`/admin/api/habits/${state.habitId}/logs/${log.id}`, { method: 'DELETE' })
-						.then(response => response.json())
-						.then(() => loadCalendar())
-						.catch(() => alert('删除失败，请稍后重试'));
-				});
-			}
+                        if (log) {
+                                button.addEventListener('click', async () => {
+                                        const confirmed = await window.AdminUI.confirm({
+                                                title: '删除打卡记录',
+                                                message: '删除该打卡记录？',
+                                                confirmText: '删除',
+                                                cancelText: '取消',
+                                                tone: 'danger',
+                                        });
+                                        if (!confirmed) {
+                                                return;
+                                        }
+                                        fetch(`/admin/api/habits/${state.habitId}/logs/${log.id}`, { method: 'DELETE' })
+                                                .then(response => response.json())
+                                                .then(() => {
+                                                        window.AdminUI.toast({ message: '已删除该打卡记录', type: 'success' });
+                                                        loadCalendar();
+                                                })
+                                                .catch(() => {
+                                                        window.AdminUI.toast({ message: '删除失败，请稍后重试', type: 'error' });
+                                                });
+                                });
+                        }
 
 			return button;
 		}
@@ -388,15 +400,27 @@
 				action.type = 'button';
 				action.textContent = '删除';
 				action.className = 'rounded-lg border border-rose-200 px-3 py-1 text-[11px] font-medium text-rose-600 transition-colors hover:bg-rose-50 dark:border-rose-500/40 dark:text-rose-300 dark:hover:bg-rose-500/10';
-				action.addEventListener('click', () => {
-					if (!confirm('确定删除这条打卡记录？')) {
-						return;
-					}
-					fetch(`/admin/api/habits/${state.habitId}/logs/${log.id}`, { method: 'DELETE' })
-						.then(response => response.json())
-						.then(() => loadCalendar())
-						.catch(() => alert('删除失败，请稍后重试'));
-				});
+                                action.addEventListener('click', async () => {
+                                        const confirmed = await window.AdminUI.confirm({
+                                                title: '删除打卡记录',
+                                                message: '确定删除这条打卡记录？',
+                                                confirmText: '删除',
+                                                cancelText: '保留',
+                                                tone: 'danger',
+                                        });
+                                        if (!confirmed) {
+                                                return;
+                                        }
+                                        fetch(`/admin/api/habits/${state.habitId}/logs/${log.id}`, { method: 'DELETE' })
+                                                .then(response => response.json())
+                                                .then(() => {
+                                                        window.AdminUI.toast({ message: '已删除该打卡记录', type: 'success' });
+                                                        loadCalendar();
+                                                })
+                                                .catch(() => {
+                                                        window.AdminUI.toast({ message: '删除失败，请稍后重试', type: 'error' });
+                                                });
+                                });
 				item.appendChild(left);
 				item.appendChild(action);
 				elements.logList.appendChild(item);

--- a/web/template/admin/post_edit.html
+++ b/web/template/admin/post_edit.html
@@ -193,8 +193,8 @@
 				if (!file) {
 					return;
 				}
-				if (typeof window.Cropper === 'undefined') {
-					alert('封面裁剪模块尚未加载，请刷新页面后重试');
+                                if (typeof window.Cropper === 'undefined') {
+                                        window.AdminUI.toast({ message: '封面裁剪模块尚未加载，请刷新页面后重试', type: 'error' });
 					return;
 				}
 				this.resetCropper();
@@ -210,15 +210,15 @@
 				}
 				try {
 					const url = new URL(this.cover.url, window.location.origin);
-					if (url.origin !== window.location.origin) {
-						alert('该封面来自外部链接，请重新上传新的封面图片');
+                                        if (url.origin !== window.location.origin) {
+                                                window.AdminUI.toast({ message: '该封面来自外部链接，请重新上传新的封面图片', type: 'warning' });
 						return;
 					}
 				} catch (error) {
 					return;
 				}
-				if (typeof window.Cropper === 'undefined') {
-					alert('封面裁剪模块尚未加载，请刷新页面后重试');
+                                if (typeof window.Cropper === 'undefined') {
+                                        window.AdminUI.toast({ message: '封面裁剪模块尚未加载，请刷新页面后重试', type: 'error' });
 					return;
 				}
 				if (this.cover.width > 0 && this.cover.height > 0) {
@@ -250,12 +250,12 @@
 								this.cover.url = data.data.url;
 								this.cover.width = data.data.width || 0;
 								this.cover.height = data.data.height || 0;
-							} else {
-								alert(data.error || data.message || '封面上传失败');
+                                                        } else {
+                                                                window.AdminUI.toast({ message: data.error || data.message || '封面上传失败', type: 'error' });
 							}
 						})
-						.catch(() => {
-							alert('封面上传失败，请稍后重试');
+                                                .catch(() => {
+                                                        window.AdminUI.toast({ message: '封面上传失败，请稍后重试', type: 'error' });
 						})
 						.finally(() => {
 							this.closeCropper();
@@ -399,8 +399,8 @@
 				if (this.editor) {
 					this.post.content = this.editor.value();
 				}
-				if (!this.cover.url || this.cover.width <= 0 || this.cover.height <= 0) {
-					alert('请上传并裁剪文章封面');
+                                if (!this.cover.url || this.cover.width <= 0 || this.cover.height <= 0) {
+                                        window.AdminUI.toast({ message: '请上传并裁剪文章封面', type: 'warning' });
 					this.loading = false;
 					return;
 				}
@@ -431,18 +431,18 @@
 				})
 					.then(response => response.json())
 					.then(data => {
-						if (data.message) {
-							if (this.editor && this.editor.clearAutosavedValue) {
-								this.editor.clearAutosavedValue();
-							}
-							alert(data.message);
-							if (!window.location.pathname.includes('/edit')) {
-								window.location.href = '/admin/posts';
-							}
-						}
-					})
-					.catch(() => {
-						alert('保存失败，请稍后重试');
+                                                if (data.message) {
+                                                        if (this.editor && this.editor.clearAutosavedValue) {
+                                                                this.editor.clearAutosavedValue();
+                                                        }
+                                                        window.AdminUI.toast({ message: data.message, type: 'success' });
+                                                        if (!window.location.pathname.includes('/edit')) {
+                                                                window.location.href = '/admin/posts';
+                                                        }
+                                                }
+                                        })
+                                        .catch(() => {
+                                                window.AdminUI.toast({ message: '保存失败，请稍后重试', type: 'error' });
 					})
 					.finally(() => {
 						this.loading = false;

--- a/web/template/admin/post_list.html
+++ b/web/template/admin/post_list.html
@@ -20,7 +20,7 @@
 
 				<label class="flex flex-col gap-2">
 					<span class="text-sm font-medium text-slate-700 dark:text-slate-200">文章状态</span>
-					<select name="status" class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 transition-colors focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-100 dark:focus:border-blue-500/60 dark:focus:ring-blue-500/30">
+                                    <select name="status" class="form-select">
 						<option value="" {{if eq .status ""}}selected{{end}}>全部</option>
 						<option value="draft" {{if eq .status "draft"}}selected{{end}}>草稿</option>
 						<option value="published" {{if eq .status "published"}}selected{{end}}>已发布</option>
@@ -177,20 +177,27 @@
 		});
 	}
 
-	function deletePost(id) {
-		if (!confirm('确定要删除这篇文章吗？')) {
-			return;
-		}
+        async function deletePost(id) {
+                const confirmed = await window.AdminUI.confirm({
+                        title: '删除文章',
+                        message: '确定要删除这篇文章吗？',
+                        confirmText: '删除',
+                        cancelText: '取消',
+                        tone: 'danger',
+                });
+                if (!confirmed) {
+                        return;
+                }
 
-		fetch(`/admin/api/posts/${id}`, { method: 'DELETE' })
-			.then(response => response.json())
-			.then(data => {
-				alert(data.message || '删除成功');
-				window.location.reload();
-			})
-			.catch(() => {
-				alert('删除失败，请稍后重试');
-			});
-	}
+                fetch(`/admin/api/posts/${id}`, { method: 'DELETE' })
+                        .then(response => response.json())
+                        .then(data => {
+                                window.AdminUI.toast({ message: data.message || '删除成功', type: 'success' });
+                                setTimeout(() => window.location.reload(), 350);
+                        })
+                        .catch(() => {
+                                window.AdminUI.toast({ message: '删除失败，请稍后重试', type: 'error' });
+                        });
+        }
 </script>
 {{end}}

--- a/web/template/layout/admin_base.html
+++ b/web/template/layout/admin_base.html
@@ -71,16 +71,290 @@
 		</nav>
 	</header>
 
-	<main class="mx-auto min-h-screen w-full max-w-6xl px-4 pb-16 pt-24">
-		{{block "content" .}}{{end}}
-	</main>
+        <main class="mx-auto min-h-screen w-full max-w-6xl px-4 pb-16 pt-24">
+                {{block "content" .}}{{end}}
+        </main>
 
-	<footer class="border-t border-slate-200 bg-white/80 backdrop-blur supports-backdrop-blur:bg-white/60 dark:border-slate-800 dark:bg-slate-950/70">
-		<div class="mx-auto flex max-w-6xl flex-col gap-2 px-4 py-6 text-sm text-slate-500 dark:text-slate-400 sm:flex-row sm:items-center sm:justify-between">
-			<span>© CommitLog</span>
+        <div x-data="commitLogToastLayer()" x-cloak class="pointer-events-none fixed inset-0 z-50 flex flex-col items-end gap-3 p-4 sm:p-6">
+                <template x-for="toast in toasts" :key="toast.id">
+                        <div x-show="toast.visible" x-transition:enter="transform ease-out duration-200" x-transition:enter-start="translate-y-2 opacity-0 scale-95" x-transition:enter-end="translate-y-0 opacity-100 scale-100" x-transition:leave="transform ease-in duration-200" x-transition:leave-start="opacity-100 scale-100" x-transition:leave-end="opacity-0 scale-95" class="pointer-events-auto w-full max-w-sm overflow-hidden rounded-2xl border border-slate-200/80 bg-white/95 shadow-xl backdrop-blur-sm dark:border-slate-700/70 dark:bg-slate-900/90">
+                                <div class="flex items-start gap-3 p-4">
+                                        <div class="mt-0.5 flex h-8 w-8 items-center justify-center rounded-full" :class="iconClass(toast.type)">
+                                                <template x-if="toast.type === 'success'">
+                                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" class="h-5 w-5">
+                                                                <circle cx="12" cy="12" r="8.25" stroke-width="1.5"></circle>
+                                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M8.75 12.25l2.25 2.25L15.25 10"></path>
+                                                        </svg>
+                                                </template>
+                                                <template x-if="toast.type === 'error'">
+                                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" class="h-5 w-5">
+                                                                <circle cx="12" cy="12" r="8.25" stroke-width="1.5"></circle>
+                                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M9 9l6 6m0-6l-6 6"></path>
+                                                        </svg>
+                                                </template>
+                                                <template x-if="toast.type === 'warning'">
+                                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" class="h-5 w-5">
+                                                                <path stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" d="M12 8v4m0 4h.01"></path>
+                                                                <path stroke-width="1.5" stroke-linejoin="round" d="M10.28 4.5l-6.16 10.67A1.5 1.5 0 005.39 17.5h13.22a1.5 1.5 0 001.27-2.33L13.72 4.5a1.5 1.5 0 00-2.44 0z"></path>
+                                                        </svg>
+                                                </template>
+                                                <template x-if="toast.type === 'info'">
+                                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" class="h-5 w-5">
+                                                                <circle cx="12" cy="12" r="8.25" stroke-width="1.5"></circle>
+                                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M12 10.5v5"></path>
+                                                                <circle cx="12" cy="8" r="0.75" fill="currentColor"></circle>
+                                                        </svg>
+                                                </template>
+                                        </div>
+                                        <div class="flex-1">
+                                                <h3 class="text-sm font-semibold text-slate-900 dark:text-slate-100" x-text="toast.title || defaultTitle(toast.type)"></h3>
+                                                <p class="mt-1 text-sm leading-relaxed text-slate-600 dark:text-slate-300" x-text="toast.message"></p>
+                                        </div>
+                                        <button type="button" class="rounded-full p-1 text-slate-400 transition-colors hover:text-slate-600 focus:outline-none focus:ring-2 focus:ring-slate-200 dark:text-slate-500 dark:hover:text-slate-200 dark:focus:ring-slate-700/60" @click="dismiss(toast.id)" aria-label="关闭提示">
+                                                <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" class="h-4 w-4">
+                                                        <path stroke-linecap="round" stroke-width="1.6" d="M5.5 5.5l9 9m0-9l-9 9"></path>
+                                                </svg>
+                                        </button>
+                                </div>
+                        </div>
+                </template>
+        </div>
+
+        <div x-data="commitLogDialogLayer()" x-show="dialog.open" x-cloak class="fixed inset-0 z-50 flex items-center justify-center px-4 py-6" x-transition.opacity @keydown.escape.window="cancel()">
+                <div class="absolute inset-0 bg-slate-900/50 backdrop-blur-sm" x-transition.opacity @click="cancel()"></div>
+                <div x-show="dialog.open" x-transition class="relative z-10 w-full max-w-md overflow-hidden rounded-2xl border border-slate-200 bg-white/95 shadow-2xl transition-colors dark:border-slate-700/70 dark:bg-slate-900/90">
+                        <button type="button" class="absolute right-4 top-4 rounded-full p-1 text-slate-400 transition-colors hover:text-slate-600 focus:outline-none focus:ring-2 focus:ring-slate-200 dark:text-slate-500 dark:hover:text-slate-200 dark:focus:ring-slate-700/60" @click="cancel()" aria-label="关闭弹窗">
+                                <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" class="h-4 w-4">
+                                        <path stroke-linecap="round" stroke-width="1.6" d="M5.5 5.5l9 9m0-9l-9 9"></path>
+                                </svg>
+                        </button>
+                        <div class="space-y-5 px-6 pb-6 pt-7">
+                                <div class="space-y-2">
+                                        <h3 class="text-lg font-semibold text-slate-900 dark:text-slate-100" x-text="dialog.title || '提示'"></h3>
+                                        <p class="text-sm leading-relaxed text-slate-600 dark:text-slate-300" x-text="dialog.message"></p>
+                                        <template x-if="dialog.description">
+                                                <p class="text-xs leading-relaxed text-slate-400 dark:text-slate-500" x-text="dialog.description"></p>
+                                        </template>
+                                </div>
+                                <div class="flex justify-end gap-3">
+                                        <button type="button" class="inline-flex items-center rounded-lg border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-slate-200 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-slate-100 dark:focus:ring-slate-700/60" @click="cancel()" x-text="dialog.cancelText || '取消'"></button>
+                                        <button type="button" class="inline-flex items-center rounded-lg px-4 py-2 text-sm font-medium text-white transition-colors focus:outline-none focus:ring-2" :class="confirmClass(dialog.tone)" @click="confirm()" x-text="dialog.confirmText || '确认'"></button>
+                                </div>
+                        </div>
+                </div>
+        </div>
+
+        <footer class="border-t border-slate-200 bg-white/80 backdrop-blur supports-backdrop-blur:bg-white/60 dark:border-slate-800 dark:bg-slate-950/70">
+                <div class="mx-auto flex max-w-6xl flex-col gap-2 px-4 py-6 text-sm text-slate-500 dark:text-slate-400 sm:flex-row sm:items-center sm:justify-between">
+                        <span>© CommitLog</span>
 			<span>打造清晰、可靠、优雅的创作体验</span>
 		</div>
-	</footer>
+        </footer>
+
+        <script>
+                window.AdminUI = window.AdminUI || {};
+                window.AdminUI.__toastQueue = window.AdminUI.__toastQueue || [];
+                window.AdminUI.__dialogQueue = window.AdminUI.__dialogQueue || [];
+                window.AdminUI.toast = window.AdminUI.toast || function (options) {
+                        const payload = typeof options === 'string' ? { message: options } : options;
+                        if (!payload || !payload.message) {
+                                return;
+                        }
+                        window.AdminUI.__toastQueue.push(payload);
+                };
+                window.AdminUI.confirm = function (options = {}) {
+                        const payload = typeof options === 'string' ? { message: options } : options;
+                        return new Promise(resolve => {
+                                window.AdminUI.__dialogQueue.push({ payload, resolve });
+                        });
+                };
+
+                document.addEventListener('alpine:init', () => {
+                        Alpine.data('commitLogToastLayer', () => ({
+                                get toasts() {
+                                        const store = Alpine.store('toast');
+                                        return store ? store.items : [];
+                                },
+                                dismiss(id) {
+                                        const store = Alpine.store('toast');
+                                        if (store) {
+                                                store.dismiss(id);
+                                        }
+                                },
+                                iconClass(type) {
+                                        switch (type) {
+                                        case 'success':
+                                                return 'bg-emerald-100 text-emerald-600 dark:bg-emerald-500/10 dark:text-emerald-300';
+                                        case 'error':
+                                                return 'bg-rose-100 text-rose-600 dark:bg-rose-500/10 dark:text-rose-300';
+                                        case 'warning':
+                                                return 'bg-amber-100 text-amber-600 dark:bg-amber-500/10 dark:text-amber-300';
+                                        default:
+                                                return 'bg-blue-100 text-blue-600 dark:bg-blue-500/10 dark:text-blue-300';
+                                        }
+                                },
+                                defaultTitle(type) {
+                                        switch (type) {
+                                        case 'success':
+                                                return '操作成功';
+                                        case 'error':
+                                                return '发生错误';
+                                        case 'warning':
+                                                return '温馨提示';
+                                        default:
+                                                return '提示';
+                                        }
+                                }
+                        }));
+
+                        Alpine.data('commitLogDialogLayer', () => ({
+                                get dialog() {
+                                        return Alpine.store('dialog') || { open: false };
+                                },
+                                cancel() {
+                                        const store = Alpine.store('dialog');
+                                        if (store) {
+                                                store.cancel();
+                                        }
+                                },
+                                confirm() {
+                                        const store = Alpine.store('dialog');
+                                        if (store) {
+                                                store.confirm();
+                                        }
+                                },
+                                confirmClass(tone) {
+                                        return tone === 'danger'
+                                                ? 'bg-rose-600 hover:bg-rose-500 dark:hover:bg-rose-500/90 focus:ring-rose-200 dark:focus:ring-rose-500/30'
+                                                : 'bg-blue-600 hover:bg-blue-500 dark:hover:bg-blue-500/90 focus:ring-blue-200 dark:focus:ring-blue-500/30';
+                                }
+                        }));
+
+                        const toastStore = {
+                                items: [],
+                                counter: 0,
+                                notify(options = {}) {
+                                        const payload = typeof options === 'string' ? { message: options } : options;
+                                        const type = payload.type || 'info';
+                                        const duration = typeof payload.duration === 'number' ? payload.duration : 3600;
+                                        const id = ++this.counter;
+                                        const toast = {
+                                                id,
+                                                title: payload.title || '',
+                                                message: payload.message || '',
+                                                type,
+                                                duration,
+                                                visible: true,
+                                        };
+                                        if (duration > 0) {
+                                                toast.timeout = setTimeout(() => this.dismiss(id), duration);
+                                        }
+                                        this.items.push(toast);
+                                        return id;
+                                },
+                                dismiss(id) {
+                                        const toast = this.items.find(item => item.id === id);
+                                        if (!toast) {
+                                                return;
+                                        }
+                                        toast.visible = false;
+                                        if (toast.timeout) {
+                                                clearTimeout(toast.timeout);
+                                        }
+                                        setTimeout(() => {
+                                                this.items = this.items.filter(item => item.id !== id);
+                                        }, 220);
+                                }
+                        };
+
+                        const dialogStore = {
+                                open: false,
+                                title: '',
+                                message: '',
+                                description: '',
+                                confirmText: '',
+                                cancelText: '',
+                                tone: 'primary',
+                                resolver: null,
+                                show(options = {}) {
+                                        if (this.open) {
+                                                this.cancel();
+                                        }
+                                        return new Promise(resolve => {
+                                                this.title = options.title || '';
+                                                this.message = options.message || '';
+                                                this.description = options.description || '';
+                                                this.confirmText = options.confirmText || '';
+                                                this.cancelText = options.cancelText || '';
+                                                this.tone = options.tone || 'primary';
+                                                this.resolver = resolve;
+                                                this.open = true;
+                                        });
+                                },
+                                confirm() {
+                                        if (this.resolver) {
+                                                this.resolver(true);
+                                        }
+                                        this.close();
+                                },
+                                cancel() {
+                                        if (this.resolver) {
+                                                this.resolver(false);
+                                        }
+                                        this.close();
+                                },
+                                close() {
+                                        this.open = false;
+                                        setTimeout(() => {
+                                                this.title = '';
+                                                this.message = '';
+                                                this.description = '';
+                                                this.confirmText = '';
+                                                this.cancelText = '';
+                                                this.tone = 'primary';
+                                                this.resolver = null;
+                                        }, 220);
+                                }
+                        };
+
+                        Alpine.store('toast', toastStore);
+                        Alpine.store('dialog', dialogStore);
+
+                        window.AdminUI.toast = function (options = {}) {
+                                const payload = typeof options === 'string' ? { message: options } : options;
+                                if (!payload || !payload.message) {
+                                        return;
+                                }
+                                Alpine.store('toast').notify(payload);
+                        };
+
+                        window.AdminUI.confirm = function (options = {}) {
+                                const payload = typeof options === 'string' ? { message: options } : options;
+                                return Alpine.store('dialog').show(payload).then(confirmed => {
+                                        if (confirmed && typeof payload.onConfirm === 'function') {
+                                                payload.onConfirm();
+                                        }
+                                        if (!confirmed && typeof payload.onCancel === 'function') {
+                                                payload.onCancel();
+                                        }
+                                        return confirmed;
+                                });
+                        };
+
+                        if (Array.isArray(window.AdminUI.__toastQueue) && window.AdminUI.__toastQueue.length > 0) {
+                                window.AdminUI.__toastQueue.forEach(payload => Alpine.store('toast').notify(payload));
+                                window.AdminUI.__toastQueue = [];
+                        }
+                        if (Array.isArray(window.AdminUI.__dialogQueue) && window.AdminUI.__dialogQueue.length > 0) {
+                                const pendingDialogs = window.AdminUI.__dialogQueue.splice(0);
+                                pendingDialogs.forEach(entry => {
+                                        window.AdminUI.confirm(entry.payload).then(result => {
+                                                entry.resolve(result);
+                                        });
+                                });
+                        }
+                });
+        </script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- replace native alerts with AdminUI toast notifications and confirmations across admin pages
- add global Alpine-based toast stack and confirm dialog in the admin base layout, queuing requests until Alpine mounts
- style select controls with a reusable Tailwind form-select utility for consistent appearance

## Testing
- npm run build:css
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d3505830348322ab664871f0e800a8