### PR TITLE
feat: enhance global error pages

### DIFF
--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
+	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -22,6 +23,11 @@ import (
 type templateRegistry struct {
 	templates map[string]*template.Template
 	funcMap   template.FuncMap
+}
+
+type errorAction struct {
+	Label string
+	Href  string
 }
 
 var imagePattern = regexp.MustCompile(`!\[[^\]]*\]\(([^)]+)\)`)
@@ -238,7 +244,9 @@ func (r *templateRegistry) Instance(name string, data interface{}) render.Render
 
 // SetupRouter 配置 Gin 引擎和路由
 func SetupRouter() *gin.Engine {
-	r := gin.Default()
+	r := gin.New()
+	r.Use(gin.Logger())
+	r.Use(recoveryWithHandler())
 
 	// 配置会话中间件
 	store := cookie.NewStore([]byte("secret"))
@@ -261,9 +269,8 @@ func SetupRouter() *gin.Engine {
 	r.GET("/tags", handlers.ShowTagArchive)
 	r.GET("/about", handlers.ShowAbout)
 
-	// 在这里定义你的路由
 	r.GET("/ping", func(c *gin.Context) {
-		c.JSON(200, gin.H{
+		c.JSON(http.StatusOK, gin.H{
 			"message": "pong",
 		})
 	})
@@ -325,5 +332,79 @@ func SetupRouter() *gin.Engine {
 		}
 	}
 
+	r.NoRoute(func(c *gin.Context) {
+		if prefersJSON(c) {
+			c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "资源不存在"})
+			return
+		}
+
+		path := c.Request.URL.Path
+		if strings.HasPrefix(path, "/admin") {
+			renderErrorPage(c, http.StatusNotFound, "后台页面走丢了", "该链接可能被移动或权限已变更，返回仪表盘继续管理站点。", &errorAction{Label: "返回仪表盘", Href: "/admin/dashboard"}, &errorAction{Label: "回到首页", Href: "/"})
+			return
+		}
+
+		renderErrorPage(c, http.StatusNotFound, "页面走丢了", "我们没有找到你想访问的内容，试试回到首页或浏览其他栏目。", &errorAction{Label: "返回首页", Href: "/"}, &errorAction{Label: "查看全部标签", Href: "/tags"})
+	})
+
 	return r
+}
+
+func recoveryWithHandler() gin.HandlerFunc {
+	return gin.CustomRecoveryWithWriter(gin.DefaultErrorWriter, func(c *gin.Context, recovered interface{}) {
+		if recovered != nil {
+			fmt.Fprintf(gin.DefaultErrorWriter, "panic recovered: %v\n", recovered)
+		}
+
+		if prefersJSON(c) {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "服务器开小差了，请稍后再试"})
+			return
+		}
+
+		path := c.Request.URL.Path
+		var primary *errorAction
+		var secondary *errorAction
+		if strings.HasPrefix(path, "/admin") {
+			primary = &errorAction{Label: "返回仪表盘", Href: "/admin/dashboard"}
+			secondary = &errorAction{Label: "回到首页", Href: "/"}
+		} else {
+			primary = &errorAction{Label: "返回首页", Href: "/"}
+			secondary = &errorAction{Label: "联系站长", Href: "/about"}
+		}
+
+		renderErrorPage(c, http.StatusInternalServerError, "服务器开小差了", "我们已经记录了这个问题，请稍后再试。", primary, secondary)
+		c.Abort()
+	})
+}
+
+func renderErrorPage(c *gin.Context, status int, headline, description string, primary, secondary *errorAction) {
+	c.HTML(status, "error.html", gin.H{
+		"title":           fmt.Sprintf("%d %s", status, http.StatusText(status)),
+		"status":          status,
+		"statusText":      http.StatusText(status),
+		"headline":        headline,
+		"description":     description,
+		"primaryAction":   primary,
+		"secondaryAction": secondary,
+		"year":            time.Now().Year(),
+	})
+}
+
+func prefersJSON(c *gin.Context) bool {
+	accept := strings.ToLower(c.GetHeader("Accept"))
+	if strings.Contains(accept, "application/json") || strings.Contains(accept, "application/problem+json") {
+		return true
+	}
+
+	path := c.Request.URL.Path
+	if strings.HasPrefix(path, "/admin/api") {
+		return true
+	}
+
+	contentType := strings.ToLower(c.ContentType())
+	if strings.Contains(contentType, "application/json") {
+		return true
+	}
+
+	return false
 }

--- a/web/template/public/error.html
+++ b/web/template/public/error.html
@@ -1,0 +1,29 @@
+{{define "content"}}
+<section class="flex min-h-[70vh] flex-col items-center justify-center px-4 py-20 text-center">
+        <div class="relative w-full max-w-2xl overflow-hidden rounded-3xl border border-slate-200/80 bg-white/80 p-10 shadow-xl backdrop-blur transition-colors duration-200 dark:border-slate-800/80 dark:bg-slate-900/70">
+                <div class="absolute -top-24 left-1/2 h-48 w-48 -translate-x-1/2 rounded-full bg-gradient-to-br from-blue-500/20 via-purple-500/20 to-pink-500/20 blur-3xl"></div>
+                <div class="relative mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-gradient-to-br from-blue-500 via-purple-500 to-pink-500 text-2xl font-semibold text-white shadow-lg">
+                        {{.status}}
+                </div>
+                <h1 class="relative mt-8 text-3xl font-semibold text-slate-900 dark:text-slate-100">{{.headline}}</h1>
+                <p class="relative mt-4 text-sm leading-6 text-slate-500 dark:text-slate-400">{{.description}}</p>
+                <div class="relative mt-10 flex flex-wrap justify-center gap-3">
+                        {{if .primaryAction}}
+                        <a href="{{.primaryAction.Href}}" class="inline-flex items-center rounded-full bg-slate-900 px-6 py-2 text-sm font-medium text-white shadow transition hover:bg-slate-700 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200">
+                                {{.primaryAction.Label}}
+                        </a>
+                        {{end}}
+                        {{if .secondaryAction}}
+                        <a href="{{.secondaryAction.Href}}" class="inline-flex items-center rounded-full border border-slate-300 px-6 py-2 text-sm font-medium text-slate-600 transition hover:border-slate-400 hover:text-slate-900 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-500 dark:hover:text-slate-100">
+                                {{.secondaryAction.Label}}
+                        </a>
+                        {{end}}
+                </div>
+        </div>
+        <div class="mt-10 text-xs text-slate-400 dark:text-slate-500">
+                <span>{{.status}} {{.statusText}}</span>
+                <span class="mx-2">·</span>
+                <span>CommitLog</span>
+        </div>
+</section>
+{{end}}


### PR DESCRIPTION
## Summary
- add a shared public error template with updated visuals for status pages
- render friendly HTML for 404/500 routes while keeping JSON responses for API requests
- introduce a custom recovery handler to capture panics and redirect users to helpful actions

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d93b02c4e0832289315fe6af3ef171