### PR TITLE
[codex] feat(dashboard): add creation heatmap widget

### DIFF
--- a/internal/handler/admin_handler.go
+++ b/internal/handler/admin_handler.go
@@ -12,6 +12,11 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
+const (
+	dashboardCreationHeatmapDays     = 365
+	dashboardCreationHeatmapTimezone = "Asia/Shanghai"
+)
+
 // ShowLoginPage 渲染登录页面
 func (a *API) ShowLoginPage(c *gin.Context) {
 	a.renderHTML(c, http.StatusOK, "login.html", gin.H{
@@ -109,14 +114,33 @@ func (a *API) ShowDashboard(c *gin.Context) {
 		}
 	}
 
+	creationHeatmap := make([]service.DailyCreationPoint, 0, dashboardCreationHeatmapDays)
+	if a.posts != nil {
+		heatmapLoc := time.FixedZone("UTC+8", 8*60*60)
+		if loadedLoc, err := time.LoadLocation(dashboardCreationHeatmapTimezone); err == nil {
+			heatmapLoc = loadedLoc
+		} else {
+			c.Error(err)
+		}
+
+		if points, err := a.posts.DailyCreationHeatmap(time.Now(), dashboardCreationHeatmapDays, heatmapLoc); err == nil {
+			creationHeatmap = points
+		} else {
+			c.Error(err)
+		}
+	}
+
 	a.renderHTML(c, http.StatusOK, "dashboard.html", gin.H{
-		"title":       "管理面板",
-		"username":    username,
-		"postCount":   postCount,
-		"tagCount":    tagCount,
-		"overview":    overview,
-		"trend":       hourlyTrend,
-		"latestDraft": latestDraft,
+		"title":            "管理面板",
+		"username":         username,
+		"postCount":        postCount,
+		"tagCount":         tagCount,
+		"overview":         overview,
+		"trend":            hourlyTrend,
+		"latestDraft":      latestDraft,
+		"creationHeatmap":  creationHeatmap,
+		"heatmapTimezone":  dashboardCreationHeatmapTimezone,
+		"heatmapRangeDays": dashboardCreationHeatmapDays,
 	})
 }
 

--- a/internal/handler/admin_handler_test.go
+++ b/internal/handler/admin_handler_test.go
@@ -76,7 +76,7 @@ func setupAdminHandlerTestDB(t *testing.T) (*gorm.DB, func()) {
 		t.Fatalf("failed to open test db: %v", err)
 	}
 
-	if err := gdb.AutoMigrate(&db.User{}, &db.Post{}, &db.Tag{}, &db.SystemSetting{}); err != nil {
+	if err := gdb.AutoMigrate(&db.User{}, &db.Post{}, &db.PostPublication{}, &db.Tag{}, &db.SystemSetting{}); err != nil {
 		t.Fatalf("failed to migrate test db: %v", err)
 	}
 
@@ -194,5 +194,121 @@ func TestShowDashboardIncludesLatestDraft(t *testing.T) {
 	}
 	if latest.ID != first.ID {
 		t.Fatalf("expected latest draft %d, got %d", first.ID, latest.ID)
+	}
+}
+
+func TestShowDashboardIncludesCreationHeatmap(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	gdb, cleanup := setupAdminHandlerTestDB(t)
+	t.Cleanup(cleanup)
+
+	loc, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Fatalf("load timezone: %v", err)
+	}
+
+	user := db.User{Username: "heatmap-admin"}
+	if err := gdb.Create(&user).Error; err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+
+	post := db.Post{
+		Content:             "# 热力图文章\n内容",
+		Status:              "published",
+		UserID:              user.ID,
+		CoverURL:            "https://example.com/cover.jpg",
+		CoverWidth:          1200,
+		CoverHeight:         800,
+		PublicationCount:    2,
+		LatestPublicationID: nil,
+	}
+	if err := gdb.Create(&post).Error; err != nil {
+		t.Fatalf("failed to create post: %v", err)
+	}
+
+	firstPublishedAt := time.Date(2026, 2, 20, 10, 0, 0, 0, loc)
+	firstPublication := db.PostPublication{
+		PostID:      post.ID,
+		Content:     post.Content,
+		Visibility:  db.PostVisibilityPublic,
+		UserID:      user.ID,
+		PublishedAt: firstPublishedAt,
+		Version:     1,
+	}
+	if err := gdb.Create(&firstPublication).Error; err != nil {
+		t.Fatalf("failed to create first publication: %v", err)
+	}
+
+	secondPublishedAt := firstPublishedAt.Add(24 * time.Hour)
+	secondPublication := db.PostPublication{
+		PostID:      post.ID,
+		Content:     "# 热力图文章（第二版）\n内容",
+		Visibility:  db.PostVisibilityPublic,
+		UserID:      user.ID,
+		PublishedAt: secondPublishedAt,
+		Version:     2,
+	}
+	if err := gdb.Create(&secondPublication).Error; err != nil {
+		t.Fatalf("failed to create second publication: %v", err)
+	}
+
+	if err := gdb.Model(&db.Post{}).Where("id = ?", post.ID).Updates(map[string]interface{}{
+		"latest_publication_id": secondPublication.ID,
+		"published_at":          secondPublishedAt,
+		"publication_count":     2,
+	}).Error; err != nil {
+		t.Fatalf("failed to update post publication pointers: %v", err)
+	}
+
+	api := &API{
+		db:     gdb,
+		posts:  service.NewPostService(gdb),
+		system: service.NewSystemSettingService(gdb),
+	}
+
+	router := gin.New()
+	renderer := &stubHTMLRender{}
+	router.HTMLRender = renderer
+	router.Use(sessions.Sessions("commitlog_session", cookie.NewStore([]byte("test-secret"))))
+	router.GET("/admin/dashboard", api.ShowDashboard)
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/admin/dashboard", nil)
+	router.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, recorder.Code)
+	}
+
+	payload, ok := renderer.lastData.(gin.H)
+	if !ok {
+		t.Fatalf("expected render payload to be gin.H, got %T", renderer.lastData)
+	}
+
+	raw, exists := payload["creationHeatmap"]
+	if !exists {
+		t.Fatal("expected creationHeatmap in payload")
+	}
+
+	heatmap, ok := raw.([]service.DailyCreationPoint)
+	if !ok {
+		t.Fatalf("expected creationHeatmap to be []service.DailyCreationPoint, got %T", raw)
+	}
+	if len(heatmap) != 365 {
+		t.Fatalf("expected 365 heatmap points, got %d", len(heatmap))
+	}
+
+	creationDate := firstPublishedAt.Format("2006-01-02")
+	creationCount := 0
+	for _, point := range heatmap {
+		if point.Date != creationDate {
+			continue
+		}
+		creationCount = point.Count
+		break
+	}
+	if creationCount != 1 {
+		t.Fatalf("expected first publication day count 1, got %d", creationCount)
 	}
 }

--- a/internal/service/post_service.go
+++ b/internal/service/post_service.go
@@ -66,6 +66,13 @@ type PublicationListResult struct {
 	PerPage      int
 }
 
+// DailyCreationPoint 表示某天首次发布文章的创作活跃度。
+type DailyCreationPoint struct {
+	Date   string   `json:"Date"`
+	Count  int      `json:"Count"`
+	Titles []string `json:"Titles"`
+}
+
 // PostInput represents fields accepted when creating or updating a post.
 type PostInput struct {
 	Title          string
@@ -392,6 +399,78 @@ func (s *PostService) LatestDraft(userID uint) (*db.Post, error) {
 
 	post.PopulateDerivedFields()
 	return &post, nil
+}
+
+// DailyCreationHeatmap 返回按天聚合的首次发布热力图数据。
+func (s *PostService) DailyCreationHeatmap(end time.Time, days int, loc *time.Location) ([]DailyCreationPoint, error) {
+	if days <= 0 {
+		days = 365
+	}
+
+	if loc == nil {
+		loc = time.UTC
+	}
+
+	if end.IsZero() {
+		end = time.Now()
+	}
+
+	endInLoc := end.In(loc)
+	endExclusive := time.Date(endInLoc.Year(), endInLoc.Month(), endInLoc.Day(), 0, 0, 0, 0, loc).AddDate(0, 0, 1)
+	start := endExclusive.AddDate(0, 0, -days)
+
+	var publications []db.PostPublication
+	if err := s.db.Model(&db.PostPublication{}).
+		Select("content", "published_at").
+		Where("version = ?", 1).
+		Where("published_at >= ? AND published_at < ?", start.UTC(), endExclusive.UTC()).
+		Order("published_at asc, id asc").
+		Find(&publications).Error; err != nil {
+		return nil, err
+	}
+
+	type dayBucket struct {
+		count  int
+		titles []string
+	}
+
+	buckets := make(map[string]*dayBucket, len(publications))
+	for i := range publications {
+		dayKey := publications[i].PublishedAt.In(loc).Format("2006-01-02")
+
+		bucket, exists := buckets[dayKey]
+		if !exists {
+			bucket = &dayBucket{
+				count:  0,
+				titles: make([]string, 0, 1),
+			}
+			buckets[dayKey] = bucket
+		}
+
+		bucket.count++
+		title := strings.TrimSpace(db.DeriveTitleFromContent(publications[i].Content))
+		if title == "" {
+			title = "未命名文章"
+		}
+		bucket.titles = append(bucket.titles, title)
+	}
+
+	points := make([]DailyCreationPoint, 0, days)
+	for cursor := start; cursor.Before(endExclusive); cursor = cursor.AddDate(0, 0, 1) {
+		dayKey := cursor.Format("2006-01-02")
+		point := DailyCreationPoint{
+			Date:   dayKey,
+			Count:  0,
+			Titles: []string{},
+		}
+		if bucket, exists := buckets[dayKey]; exists {
+			point.Count = bucket.count
+			point.Titles = bucket.titles
+		}
+		points = append(points, point)
+	}
+
+	return points, nil
 }
 
 // ListPublished 返回最新发布的文章快照列表

--- a/internal/service/post_service_test.go
+++ b/internal/service/post_service_test.go
@@ -277,6 +277,98 @@ func TestPostService_LatestDraftReturnsNotFoundWhenEmpty(t *testing.T) {
 	}
 }
 
+func TestPostService_DailyCreationHeatmapCountsFirstPublicationOnly(t *testing.T) {
+	gdb := setupPostServiceTestDB(t)
+	svc := NewPostService(gdb)
+
+	loc, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		t.Fatalf("load timezone: %v", err)
+	}
+
+	user := db.User{Username: "heatmap-publisher"}
+	if err := gdb.Create(&user).Error; err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	firstPost, err := svc.Create(PostInput{
+		Content:     "# 第一篇\n内容",
+		Summary:     "第一篇摘要",
+		UserID:      user.ID,
+		CoverURL:    "https://example.com/first.jpg",
+		CoverWidth:  1200,
+		CoverHeight: 800,
+	})
+	if err != nil {
+		t.Fatalf("create first post: %v", err)
+	}
+
+	secondPost, err := svc.Create(PostInput{
+		Content:     "# 第二篇\n内容",
+		Summary:     "第二篇摘要",
+		UserID:      user.ID,
+		CoverURL:    "https://example.com/second.jpg",
+		CoverWidth:  1200,
+		CoverHeight: 800,
+	})
+	if err != nil {
+		t.Fatalf("create second post: %v", err)
+	}
+
+	firstPublishAt := time.Date(2026, 3, 1, 1, 0, 0, 0, loc)
+	if _, err := svc.Publish(firstPost.ID, user.ID, &firstPublishAt); err != nil {
+		t.Fatalf("publish first post first time: %v", err)
+	}
+
+	// 再次发布同一篇文章，热力图口径不应重复计数。
+	republishAt := time.Date(2026, 3, 2, 2, 0, 0, 0, loc)
+	if _, err := svc.Publish(firstPost.ID, user.ID, &republishAt); err != nil {
+		t.Fatalf("republish first post: %v", err)
+	}
+
+	secondPublishAt := time.Date(2026, 3, 1, 10, 0, 0, 0, loc)
+	if _, err := svc.Publish(secondPost.ID, user.ID, &secondPublishAt); err != nil {
+		t.Fatalf("publish second post first time: %v", err)
+	}
+
+	end := time.Date(2026, 3, 2, 12, 0, 0, 0, loc)
+	points, err := svc.DailyCreationHeatmap(end, 2, loc)
+	if err != nil {
+		t.Fatalf("query creation heatmap: %v", err)
+	}
+
+	if len(points) != 2 {
+		t.Fatalf("expected 2 heatmap points, got %d", len(points))
+	}
+
+	if points[0].Date != "2026-03-01" {
+		t.Fatalf("expected first day to be 2026-03-01, got %s", points[0].Date)
+	}
+	if points[1].Date != "2026-03-02" {
+		t.Fatalf("expected second day to be 2026-03-02, got %s", points[1].Date)
+	}
+
+	if points[0].Count != 2 {
+		t.Fatalf("expected 2 first-publication creations on 2026-03-01, got %d", points[0].Count)
+	}
+	if points[1].Count != 0 {
+		t.Fatalf("expected republish day count to stay 0, got %d", points[1].Count)
+	}
+
+	if len(points[0].Titles) != 2 {
+		t.Fatalf("expected 2 titles on 2026-03-01, got %d", len(points[0].Titles))
+	}
+	if points[0].Titles[0] != "第一篇" {
+		t.Fatalf("expected first title 第一篇, got %s", points[0].Titles[0])
+	}
+	if points[0].Titles[1] != "第二篇" {
+		t.Fatalf("expected second title 第二篇, got %s", points[0].Titles[1])
+	}
+	if len(points[1].Titles) != 0 {
+		t.Fatalf("expected empty titles on 2026-03-02, got %d", len(points[1].Titles))
+	}
+}
+
 func TestPostService_ListPublishedSplitsSearchTokens(t *testing.T) {
 	gdb := setupPostServiceTestDB(t)
 	svc := NewPostService(gdb)

--- a/tests/creation_heatmap.test.js
+++ b/tests/creation_heatmap.test.js
@@ -1,0 +1,78 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  normalizePoints,
+  computeIntensity,
+  summarizeHeatmap,
+} = require("../web/static/js/creation_heatmap");
+
+test("normalizePoints sorts dates and sanitizes payload", () => {
+  const points = normalizePoints([
+    {
+      Date: "2026-03-03",
+      Count: "2.4",
+      Titles: ["  标题 A  ", "", " ", null, "标题 B"],
+    },
+    {
+      Date: "2026-03-01",
+      Count: -3,
+      Titles: ["标题 C"],
+    },
+    {
+      Date: "",
+      Count: 8,
+      Titles: ["无效日期"],
+    },
+  ]);
+
+  assert.deepEqual(points, [
+    { date: "2026-03-01", count: 0, titles: ["标题 C"] },
+    { date: "2026-03-03", count: 2, titles: ["标题 A", "标题 B"] },
+  ]);
+});
+
+test("computeIntensity maps count into 0-4 levels", () => {
+  assert.equal(computeIntensity(0, 5), 0);
+  assert.equal(computeIntensity(1, 5), 1);
+  assert.equal(computeIntensity(2, 5), 2);
+  assert.equal(computeIntensity(3, 5), 3);
+  assert.equal(computeIntensity(4, 5), 4);
+  assert.equal(computeIntensity(8, 5), 4);
+});
+
+test("summarizeHeatmap builds display cells and streak stats", () => {
+  const summary = summarizeHeatmap([
+    { Date: "2026-03-01", Count: 2, Titles: ["第一篇", "第二篇"] },
+    { Date: "2026-03-02", Count: 1, Titles: ["第三篇"] },
+    { Date: "2026-03-03", Count: 0, Titles: [] },
+    { Date: "2026-03-04", Count: 3, Titles: ["第四篇"] },
+  ]);
+
+  assert.equal(summary.totalCount, 6);
+  assert.equal(summary.activeDays, 3);
+  assert.equal(summary.longestStreak, 2);
+  assert.equal(summary.currentStreak, 1);
+  assert.equal(summary.maxCount, 3);
+
+  assert.equal(summary.weeks, 2);
+  assert.equal(summary.displayCells.length, 14);
+  assert.equal(summary.displayCells.slice(0, 6).every((cell) => cell.empty), true);
+
+  assert.deepEqual(summary.displayCells[6], {
+    empty: false,
+    index: 0,
+    date: "2026-03-01",
+    count: 2,
+    titles: ["第一篇", "第二篇"],
+    level: 3,
+  });
+  assert.deepEqual(summary.displayCells[9], {
+    empty: false,
+    index: 3,
+    date: "2026-03-04",
+    count: 3,
+    titles: ["第四篇"],
+    level: 4,
+  });
+});

--- a/web/static/js/creation_heatmap.js
+++ b/web/static/js/creation_heatmap.js
@@ -1,0 +1,170 @@
+(function (root, factory) {
+  if (typeof module === "object" && module.exports) {
+    module.exports = factory();
+  } else {
+    root.CreationHeatmap = factory();
+  }
+})(this, function () {
+  const dateKeyPattern = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+  function toNumber(value) {
+    const num = Number(value);
+    return Number.isFinite(num) ? num : 0;
+  }
+
+  function parseDateKey(raw) {
+    const value = String(raw || "").trim();
+    const match = dateKeyPattern.exec(value);
+    if (!match) {
+      return null;
+    }
+
+    const month = Number(match[2]);
+    const day = Number(match[3]);
+    if (month < 1 || month > 12 || day < 1 || day > 31) {
+      return null;
+    }
+
+    return value;
+  }
+
+  function normalizePoints(points) {
+    const entries = Array.isArray(points) ? points : [];
+    const normalized = [];
+
+    entries.forEach((entry) => {
+      const date = parseDateKey(entry && entry.Date);
+      if (!date) {
+        return;
+      }
+
+      const count = Math.max(0, Math.round(toNumber(entry && entry.Count)));
+      const titles = Array.isArray(entry && entry.Titles)
+        ? entry.Titles
+            .map((title) => String(title || "").trim())
+            .filter((title) => title.length > 0)
+        : [];
+
+      normalized.push({ date, count, titles });
+    });
+
+    normalized.sort((a, b) => a.date.localeCompare(b.date));
+    return normalized;
+  }
+
+  function computeIntensity(count, maxCount) {
+    const safeCount = Math.max(0, Math.round(toNumber(count)));
+    const safeMax = Math.max(0, Math.round(toNumber(maxCount)));
+    if (safeCount <= 0 || safeMax <= 0) {
+      return 0;
+    }
+
+    const ratio = safeCount / safeMax;
+    if (ratio >= 0.75) {
+      return 4;
+    }
+    if (ratio >= 0.5) {
+      return 3;
+    }
+    if (ratio >= 0.25) {
+      return 2;
+    }
+    return 1;
+  }
+
+  function computeStreaks(points) {
+    const entries = Array.isArray(points) ? points : [];
+    let longest = 0;
+    let current = 0;
+
+    entries.forEach((point) => {
+      if ((point && point.count) > 0) {
+        current += 1;
+        if (current > longest) {
+          longest = current;
+        }
+        return;
+      }
+      current = 0;
+    });
+
+    let tail = 0;
+    for (let index = entries.length - 1; index >= 0; index -= 1) {
+      if ((entries[index] && entries[index].count) > 0) {
+        tail += 1;
+        continue;
+      }
+      break;
+    }
+
+    return { longestStreak: longest, currentStreak: tail };
+  }
+
+  function mondayFirstWeekday(dateKey) {
+    const day = new Date(`${dateKey}T00:00:00Z`).getUTCDay();
+    return (day + 6) % 7;
+  }
+
+  function buildDisplayCells(points, maxCount) {
+    const entries = Array.isArray(points) ? points : [];
+    if (entries.length === 0) {
+      return [];
+    }
+
+    const leading = mondayFirstWeekday(entries[0].date);
+    const cells = [];
+
+    for (let index = 0; index < leading; index += 1) {
+      cells.push({ empty: true });
+    }
+
+    entries.forEach((point, index) => {
+      cells.push({
+        empty: false,
+        index,
+        date: point.date,
+        count: point.count,
+        titles: point.titles,
+        level: computeIntensity(point.count, maxCount),
+      });
+    });
+
+    const trailing = (7 - (cells.length % 7)) % 7;
+    for (let index = 0; index < trailing; index += 1) {
+      cells.push({ empty: true });
+    }
+
+    return cells;
+  }
+
+  function summarizeHeatmap(points) {
+    const normalized = normalizePoints(points);
+    const maxCount = normalized.reduce(
+      (max, point) => Math.max(max, point.count),
+      0,
+    );
+    const totalCount = normalized.reduce((sum, point) => sum + point.count, 0);
+    const activeDays = normalized.filter((point) => point.count > 0).length;
+    const streaks = computeStreaks(normalized);
+    const displayCells = buildDisplayCells(normalized, maxCount);
+    const weeks = displayCells.length > 0 ? Math.ceil(displayCells.length / 7) : 0;
+
+    return {
+      points: normalized,
+      displayCells,
+      weeks,
+      maxCount,
+      totalCount,
+      activeDays,
+      longestStreak: streaks.longestStreak,
+      currentStreak: streaks.currentStreak,
+    };
+  }
+
+  return {
+    normalizePoints,
+    computeIntensity,
+    computeStreaks,
+    summarizeHeatmap,
+  };
+});

--- a/web/template/admin/dashboard.html
+++ b/web/template/admin/dashboard.html
@@ -530,6 +530,157 @@
         </div>
     </section>
 
+    <section
+        class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition-colors dark:border-slate-800 dark:bg-slate-900/80"
+        x-data="creationHeatmap({{toJSON .creationHeatmap}}, '{{.heatmapTimezone}}', {{.heatmapRangeDays}})"
+        x-init="init()"
+        x-cloak
+    >
+        <div
+            class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between"
+        >
+            <div>
+                <div
+                    class="inline-flex items-center gap-2 rounded-full bg-emerald-50 px-3 text-xs font-semibold text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-200"
+                >
+                    <span>创作热力图 · 过去 {{.heatmapRangeDays}} 天</span>
+                </div>
+            </div>
+            <div class="grid grid-cols-2 gap-2 text-center text-xs sm:grid-cols-4">
+                <div class="rounded-lg bg-slate-100/80 px-3 py-2 dark:bg-slate-950/45">
+                    <p class="text-slate-500 dark:text-slate-400">总发布</p>
+                    <p
+                        class="mt-0.5 text-lg font-medium text-slate-900 dark:text-slate-100"
+                        x-text="summary.totalCount"
+                    ></p>
+                </div>
+                <div class="rounded-lg bg-slate-100/80 px-3 py-2 dark:bg-slate-950/45">
+                    <p class="text-slate-500 dark:text-slate-400">创作日</p>
+                    <p
+                        class="mt-0.5 text-lg font-medium text-slate-900 dark:text-slate-100"
+                        x-text="summary.activeDays"
+                    ></p>
+                </div>
+                <div class="rounded-lg bg-slate-100/80 px-3 py-2 dark:bg-slate-950/45">
+                    <p class="text-slate-500 dark:text-slate-400">当前连续</p>
+                    <p
+                        class="mt-0.5 text-lg font-medium text-slate-900 dark:text-slate-100"
+                        x-text="summary.currentStreak"
+                    ></p>
+                </div>
+                <div class="rounded-lg bg-slate-100/80 px-3 py-2 dark:bg-slate-950/45">
+                    <p class="text-slate-500 dark:text-slate-400">最长连续</p>
+                    <p
+                        class="mt-0.5 text-lg font-medium text-slate-900 dark:text-slate-100"
+                        x-text="summary.longestStreak"
+                    ></p>
+                </div>
+            </div>
+        </div>
+
+        <div class="mt-4 space-y-2.5">
+            <div class="text-[11px] text-slate-500 dark:text-slate-400">
+                <span x-text="rangeLabel"></span>
+            </div>
+            <div class="relative" x-ref="heatmapSurface" @mouseleave="hideTooltip()">
+                <div
+                    class="overflow-x-auto rounded-xl bg-slate-100/80 p-3 dark:bg-slate-950/40"
+                >
+                    <div class="inline-flex gap-2">
+                        <div
+                            class="grid grid-rows-7 gap-[3px] pt-[1px] text-[9px] text-slate-400 dark:text-slate-500"
+                        >
+                            <span>一</span>
+                            <span></span>
+                            <span>三</span>
+                            <span></span>
+                            <span>五</span>
+                            <span></span>
+                            <span>日</span>
+                        </div>
+                        <div class="grid grid-flow-col grid-rows-7 gap-[3px]">
+                            <template
+                                x-for="(cell, cellIndex) in displayCells"
+                                :key="`heat-cell-${cellIndex}-${cell.date || 'empty'}`"
+                            >
+                                <div>
+                                    <template x-if="cell.empty">
+                                        <span class="block h-2.5 w-2.5 rounded-[2px] bg-slate-200/85 dark:bg-slate-800/80"></span>
+                                    </template>
+                                    <template x-if="!cell.empty">
+                                        <button
+                                            type="button"
+                                            class="block h-2.5 w-2.5 rounded-[2px] transition-transform duration-150 hover:scale-105 focus:outline-none focus-visible:scale-105"
+                                            :class="levelClass(cell.level, isSelected(cell))"
+                                            :title="cellTitle(cell)"
+                                            @mouseenter="showTooltip($event, cell)"
+                                            @mousemove="moveTooltip($event)"
+                                            @mouseleave="hideTooltip()"
+                                            @focus="showTooltip($event, cell)"
+                                            @blur="hideTooltip()"
+                                            @click="showTooltip($event, cell)"
+                                        ></button>
+                                    </template>
+                                </div>
+                            </template>
+                        </div>
+                    </div>
+                </div>
+                <div
+                    x-show="tooltip.visible && selectedPoint"
+                    x-transition.opacity.duration.100ms
+                    x-cloak
+                    class="pointer-events-none absolute z-20 w-56 rounded-lg bg-white/95 px-3 py-2 text-xs text-slate-600 shadow-lg ring-1 ring-slate-200/80 backdrop-blur dark:bg-slate-900/95 dark:text-slate-300 dark:ring-slate-700/80"
+                    :style="tooltipStyle()"
+                >
+                    <template x-if="selectedPoint">
+                        <div class="space-y-2">
+                            <div class="space-y-0.5">
+                                <p
+                                    class="text-[11px] text-slate-500 dark:text-slate-400"
+                                    x-text="formatDay(selectedPoint.date)"
+                                ></p>
+                                <p
+                                    class="text-sm font-semibold text-slate-900 dark:text-slate-100"
+                                    x-text="`${selectedPoint.count} 次发布`"
+                                ></p>
+                            </div>
+                            <template x-if="selectedPoint.count > 0">
+                                <div class="space-y-1.5">
+                                    <p class="text-[11px] font-semibold text-slate-600 dark:text-slate-300">
+                                        当天发布文章
+                                    </p>
+                                    <ul class="space-y-1 text-[11px]">
+                                        <template
+                                            x-for="(title, titleIndex) in selectedPoint.titles"
+                                            :key="`heat-title-tip-${titleIndex}`"
+                                        >
+                                            <li class="truncate rounded bg-slate-100 px-1.5 py-0.5 text-slate-700 dark:bg-slate-800/70 dark:text-slate-200" x-text="title"></li>
+                                        </template>
+                                    </ul>
+                                </div>
+                            </template>
+                            <template x-if="selectedPoint.count === 0">
+                                <p class="text-[11px] text-slate-500 dark:text-slate-400">
+                                    这一天没有新的首次发布记录。
+                                </p>
+                            </template>
+                        </div>
+                    </template>
+                </div>
+            </div>
+            <div class="flex items-center gap-1 text-[11px] text-slate-500 dark:text-slate-400">
+                <span>少</span>
+                <span class="h-2.5 w-2.5 rounded-[2px] bg-slate-200/85 dark:bg-slate-800/80"></span>
+                <span class="h-2.5 w-2.5 rounded-[2px] bg-emerald-100 dark:bg-emerald-900/30"></span>
+                <span class="h-2.5 w-2.5 rounded-[2px] bg-emerald-300 dark:bg-emerald-700/50"></span>
+                <span class="h-2.5 w-2.5 rounded-[2px] bg-emerald-500 dark:bg-emerald-500/70"></span>
+                <span class="h-2.5 w-2.5 rounded-[2px] bg-emerald-700 dark:bg-emerald-300"></span>
+                <span>多</span>
+            </div>
+        </div>
+    </section>
+
     <section class="grid gap-6 lg:grid-cols-3">
         <div
             class="space-y-5 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition-colors dark:border-slate-800 dark:bg-slate-900/80 lg:col-span-2"
@@ -683,8 +834,246 @@
         </div>
     </section>
 </div>
+<script src="/static/js/creation_heatmap.js"></script>
 <script src="/static/js/traffic_trend.js"></script>
 <script>
+    function creationHeatmap(points, timezone, rangeDays) {
+        const entries = Array.isArray(points) ? points : [];
+        return {
+            points: entries,
+            timezone:
+                typeof timezone === "string" && timezone
+                    ? timezone
+                    : "Asia/Shanghai",
+            rangeDays: Number(rangeDays) > 0 ? Number(rangeDays) : 365,
+            helper: null,
+            formatters: null,
+            summary: {
+                points: [],
+                displayCells: [],
+                weeks: 0,
+                maxCount: 0,
+                totalCount: 0,
+                activeDays: 0,
+                longestStreak: 0,
+                currentStreak: 0,
+            },
+            selectedIndex: -1,
+            tooltip: {
+                visible: false,
+                left: 0,
+                top: 0,
+            },
+            init() {
+                this.helper = window.CreationHeatmap || null;
+                this.ensureFormatters();
+                this.rebuild();
+            },
+            ensureFormatters() {
+                if (this.formatters) {
+                    return;
+                }
+                this.formatters = {
+                    day: new Intl.DateTimeFormat("zh-CN", {
+                        year: "numeric",
+                        month: "2-digit",
+                        day: "2-digit",
+                        timeZone: this.timezone,
+                    }),
+                    range: new Intl.DateTimeFormat("zh-CN", {
+                        year: "numeric",
+                        month: "2-digit",
+                        day: "2-digit",
+                        timeZone: this.timezone,
+                    }),
+                };
+            },
+            rebuild() {
+                if (
+                    this.helper &&
+                    typeof this.helper.summarizeHeatmap === "function"
+                ) {
+                    this.summary = this.helper.summarizeHeatmap(this.points);
+                } else {
+                    this.summary = {
+                        points: [],
+                        displayCells: [],
+                        weeks: 0,
+                        maxCount: 0,
+                        totalCount: 0,
+                        activeDays: 0,
+                        longestStreak: 0,
+                        currentStreak: 0,
+                    };
+                }
+
+                this.selectedIndex = -1;
+            },
+            parseDate(dateKey) {
+                if (!dateKey) {
+                    return null;
+                }
+                return new Date(`${dateKey}T00:00:00Z`);
+            },
+            formatDay(dateKey) {
+                const date = this.parseDate(dateKey);
+                if (!date || Number.isNaN(date.getTime())) {
+                    return "";
+                }
+                return this.formatters.day.format(date);
+            },
+            formatRangeDay(dateKey) {
+                const date = this.parseDate(dateKey);
+                if (!date || Number.isNaN(date.getTime())) {
+                    return "";
+                }
+                return this.formatters.range.format(date);
+            },
+            get rangeLabel() {
+                if (!this.summary.points.length) {
+                    return "暂无发布记录";
+                }
+                const first = this.summary.points[0];
+                const last = this.summary.points[this.summary.points.length - 1];
+                return `${this.formatRangeDay(first.date)} - ${this.formatRangeDay(last.date)}`;
+            },
+            get displayCells() {
+                return this.summary.displayCells || [];
+            },
+            get selectedPoint() {
+                if (
+                    this.selectedIndex < 0 ||
+                    this.selectedIndex >= this.summary.points.length
+                ) {
+                    return null;
+                }
+                return this.summary.points[this.selectedIndex] || null;
+            },
+            selectByCell(cell) {
+                if (!cell || cell.empty || typeof cell.index !== "number") {
+                    return;
+                }
+                this.selectedIndex = cell.index;
+            },
+            showTooltip(event, cell) {
+                this.selectByCell(cell);
+                if (!this.selectedPoint) {
+                    this.hideTooltip();
+                    return;
+                }
+                this.tooltip.visible = true;
+                this.updateTooltipPosition(event);
+            },
+            moveTooltip(event) {
+                if (!this.tooltip.visible) {
+                    return;
+                }
+                this.updateTooltipPosition(event);
+            },
+            hideTooltip() {
+                this.tooltip.visible = false;
+                this.selectedIndex = -1;
+            },
+            updateTooltipPosition(event) {
+                const surface = this.$refs.heatmapSurface;
+                if (!surface) {
+                    return;
+                }
+
+                const surfaceRect = surface.getBoundingClientRect();
+                const eventPoint = this.resolveEventPoint(event);
+
+                let left = eventPoint.x - surfaceRect.left + 12;
+                let top = eventPoint.y - surfaceRect.top + 12;
+
+                const estimatedWidth = 224;
+                const titleCount = this.selectedPoint?.titles?.length || 0;
+                const estimatedHeight = this.selectedPoint && this.selectedPoint.count > 0
+                    ? Math.min(220, 96 + titleCount * 20)
+                    : 96;
+                const padding = 8;
+
+                if (left + estimatedWidth + padding > surfaceRect.width) {
+                    left = surfaceRect.width - estimatedWidth - padding;
+                }
+                if (top + estimatedHeight + padding > surfaceRect.height) {
+                    top = surfaceRect.height - estimatedHeight - padding;
+                }
+                if (left < padding) {
+                    left = padding;
+                }
+                if (top < padding) {
+                    top = padding;
+                }
+
+                this.tooltip.left = left;
+                this.tooltip.top = top;
+            },
+            resolveEventPoint(event) {
+                if (
+                    event &&
+                    Number.isFinite(event.clientX) &&
+                    Number.isFinite(event.clientY)
+                ) {
+                    return {
+                        x: event.clientX,
+                        y: event.clientY,
+                    };
+                }
+
+                const target = event?.currentTarget;
+                if (target && typeof target.getBoundingClientRect === "function") {
+                    const rect = target.getBoundingClientRect();
+                    return {
+                        x: rect.left + rect.width / 2,
+                        y: rect.top + rect.height / 2,
+                    };
+                }
+
+                const surface = this.$refs.heatmapSurface;
+                if (surface && typeof surface.getBoundingClientRect === "function") {
+                    const rect = surface.getBoundingClientRect();
+                    return {
+                        x: rect.left + rect.width / 2,
+                        y: rect.top + rect.height / 2,
+                    };
+                }
+
+                return {
+                    x: 0,
+                    y: 0,
+                };
+            },
+            tooltipStyle() {
+                return `left: ${this.tooltip.left}px; top: ${this.tooltip.top}px;`;
+            },
+            isSelected(cell) {
+                return this.tooltip.visible && !cell.empty && cell.index === this.selectedIndex;
+            },
+            levelClass(level, selected) {
+                const safeLevel = Number(level) || 0;
+                const palette = [
+                    "bg-slate-100 dark:bg-slate-800/60",
+                    "bg-emerald-100 dark:bg-emerald-900/30",
+                    "bg-emerald-300 dark:bg-emerald-700/50",
+                    "bg-emerald-500 dark:bg-emerald-500/70",
+                    "bg-emerald-700 dark:bg-emerald-300",
+                ];
+                const base = palette[Math.min(Math.max(safeLevel, 0), 4)];
+                if (!selected) {
+                    return base;
+                }
+                return `${base} brightness-110`;
+            },
+            cellTitle(cell) {
+                if (!cell || cell.empty) {
+                    return "";
+                }
+                return `${this.formatDay(cell.date)} · ${cell.count} 次发布`;
+            },
+        };
+    }
+
     function trafficTrend(points) {
         const entries = Array.isArray(points) ? points : [];
         return {

--- a/web/template/admin/post_edit.html
+++ b/web/template/admin/post_edit.html
@@ -63,6 +63,12 @@
         color: inherit;
     }
 
+    .milkdown-immersive-shell .milkdown .ProseMirror h1,
+    .milkdown-preview .milkdown .ProseMirror h1,
+    #milkdown-app > div > .ProseMirror h1 {
+        line-height: 2rem !important;
+    }
+
     {{template "milkdown_callout_styles"}}
 
     /* 全局隐藏滚动条但保留滚动功能 */

--- a/web/template/public/post_detail.html
+++ b/web/template/public/post_detail.html
@@ -36,6 +36,10 @@
     .post-content :is(h1, h2, h3, h4, h5, h6) b {
         color: inherit;
     }
+
+    .page-title {
+        line-height: 2rem;
+    }
     {{template "milkdown_callout_styles"}}
 
     [data-toc-content] h1,


### PR DESCRIPTION
## 问题背景
当前管理面板只能看到总量与趋势统计，无法回答“过去一年具体哪几天有新文章首次发布”这类高频运营问题。对作者而言，这会直接影响对创作节奏、连续创作状态和停更风险的判断，导致面板在复盘价值上不完整。

## 影响与根因
用户影响体现在两个层面：第一，管理面板缺少按天粒度的创作热力图，无法快速识别活跃日和空窗期；第二，已有统计口径没有明确区分“首次发布”和“重复发布”，容易在内容二次发布场景下放大活跃度。根因是服务层没有提供“按天聚合且仅统计 version=1 首次发布”的数据接口，Dashboard 模板也缺少对应的可视化和交互承载。

## 修复方案
本次修复在服务层新增 `DailyCreationHeatmap` 聚合能力，以固定时间窗口返回每日计数与标题列表，且仅统计 `PostPublication.version = 1` 的记录，避免重复发布重复计数；在管理端 Handler 中接入该能力并注入时区与窗口参数，确保模板可直接渲染；在前端新增 `creation_heatmap.js`，实现数据规范化、强度分级、连续创作统计与网格映射；在 Dashboard 中新增热力图卡片、悬浮提示与摘要指标，并补充样式细节以保证标题行高一致；同时为公开文章页标题补充行高修正，避免样式回归。

## 验证与测试
本次变更新增并通过了服务层与 Handler 层单元测试，覆盖“仅首次发布计数”“365 天数据长度”“目标日期计数正确”等关键行为；新增前端 Node 测试覆盖热力图数据清洗、强度映射和展示网格统计逻辑。已在本地执行 `make lint`、`make test`、`make build`，全部通过。额外尝试执行 `pnpm exec playwright test tests/creation_heatmap.test.js` 用于浏览器侧回归，但当前仓库未安装 Playwright CLI（报错 `Command "playwright" not found`），因此未完成该项自动化浏览器回归。
